### PR TITLE
bug fix on train_example: single sequences no longer split

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea/
+*.DS_Store
+__pycache__/

--- a/train_example.py
+++ b/train_example.py
@@ -34,18 +34,8 @@ tokenizer = AutoTokenizer.from_pretrained("facebook/esm2_t12_35M_UR50D")
 tokenizer.model_max_length = 1e8
 
 
-def remove_labels(example):
-    # n.b. it would probably be better to do this on the file level, or at file loading level, or on the fly
-    example["text"] = "\n".join(
-        [line for line in example["text"].split("\n") if not line.startswith(">")]
-    )
-    return example
-
-
 def subsample(example, max_length=5000, sequence_separator="\n"):
-    sequences = [
-        line for line in example["text"].split("\n") if not line.startswith(">")
-    ]
+    sequences = [''.join(one_seq.split('\n')[1:]) for one_seq in example['text'].split('>')[1:]]
     random.shuffle(sequences)
     cumulative_lengths = list(
         itertools.accumulate([len(s) + 1 for s in sequences])


### PR DESCRIPTION
Interpro example fastas have sequences that span multiple lines in the file. Previous implementation split on new lines.