### PR TITLE
script to compute pairwise sequence identity for a fasta file

### DIFF
--- a/scripts/sequence_identity.py
+++ b/scripts/sequence_identity.py
@@ -13,6 +13,7 @@ def compute_pairwise_identity(seq1, seq2):
     seq_length = min(len(seq1), len(seq2))
     matches = global_align[0][2]
     percent_match = (matches / seq_length) * 100
+    # print(global_align[0])
     return percent_match
 
 


### PR DESCRIPTION
* example foldseek clusters are < 50% seq id (as expected since the clusters are clusters of representatives of 50% seq id mmseqs clusters)