### PR TITLE
Subsample lines

### DIFF
--- a/src/data/utils.py
+++ b/src/data/utils.py
@@ -164,7 +164,7 @@ def load_protein_dataset(
             lines = subsample_fasta_lines(
                 lines,
                 max_fasta_lines_to_preprocess,
-                shuffle=shuffle
+                shuffle=shuffle,
             )
         # N.B. for stockholm format we need to check that sequences aren't split over
         # multiple lines


### PR DESCRIPTION
calculates a generous upper bound of number of fasta lines that should be pre-processed to ensure that there is at least max_tokens in the resultant sub-sampled fasta file.
If the number of lines in the msa exceeds the upper bound it randomly samples a fixed number of sequences in the fasta for pre-processing. later subsampling of the fasta file based on max_tokens reduces this further (this is left unchanged)

Assumptions:

- fasta format for example['text'] where each new entry starts with '>'
- some very conservative assumptions about the minimum number of tokens that each line in the fasta file will add (we assume each line will add at least 5 tokens, but we count the title lines in that too (lines starting with '>')

Note that it can handle fastas where the sequence is split over multiple lines

also perhaps there is a better way to handle setting the random seed?