### PR TITLE
one line bug fix: num_shards

### DIFF
--- a/src/data/builders/hf_datasets.py
+++ b/src/data/builders/hf_datasets.py
@@ -226,7 +226,7 @@ class FileBasedHFProteinDataset(BaseProteinDataset):
         )  # formatting needs to be set before filter/map
 
         if self.streaming:
-            print(f"Dataset n shards: {dataset.num_shards}")
+            print(f"Dataset n shards: {dataset.n_shards}")
         else:
             print(f"Loaded dataset {self.name} with {len(dataset)} samples")
         if verbose:


### PR DESCRIPTION
Fixes this error

  File "/Users/judewells/Documents/dataScienceProgramming/cath_plm/profam/src/data/datamodule.py", line 96, in setup
    dataset = dataset_builder.load(
              ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/judewells/Documents/dataScienceProgramming/cath_plm/profam/src/data/builders/hf_datasets.py", line 229, in load
    print(f"Dataset n shards: {dataset.num_shards}")
                               ^^^^^^^^^^^^^^^^^^
AttributeError: 'IterableDataset' object has no attribute 'num_shards'
