### PR TITLE
remove assert that raises error when resuming training

### DIFF
--- a/src/utils/throughput.py
+++ b/src/utils/throughput.py
@@ -140,10 +140,6 @@ class Throughput:
 
         """
         self._time.append(time)
-        if samples < batches:
-            raise ValueError(
-                f"Expected samples ({samples}) to be greater or equal than batches ({batches})"
-            )
         self._batches.append(batches)
         self._samples.append(samples)
         if proteins is not None:


### PR DESCRIPTION
Removed assert which was raising an error when the training was resumed from a checkpoint (batches are saved as part of the trainer state and are restored with checkpoint while samples starts again from zero)

error:
```
"/SAN/orengolab/cath_plm/ProFam/profam/src/utils/throughput.py", line 144, in update
    raise ValueError(
ValueError: Expected samples (1) to be greater or equal than batches (33201)
```