### PR TITLE
don't call split_dataset_by_node on val sets

### DIFF
--- a/src/data/datamodule.py
+++ b/src/data/datamodule.py
@@ -244,9 +244,7 @@ class ProteinDataMixture(LightningDataModule):
                             rank=self.trainer.global_rank,
                             world_size=world_size,
                         )
-                        dataset = dataset.with_format(
-                            "numpy"
-                        )
+                        dataset = dataset.with_format("numpy")
                 self.val_datasets.append(dataset)
                 self.val_dataset_names.append(v_ds_name)
                 print(


### PR DESCRIPTION
Fixes bug where problems are caused by trying to call split_dataset_by_node on map datasets