### PR TITLE
fix pack batches WIP

### DIFF
--- a/src/data/processors/batch_transforms.py
+++ b/src/data/processors/batch_transforms.py
@@ -100,7 +100,20 @@ def pack_batches(
                 examples_to_pack.append(truncated_example)
                 packed_examples.append(
                     pack_examples(examples_to_pack)
-                )  # TODO: check this
+                )
+                examples_to_pack = []
+                total_packed_tokens = 0
+            
+            elif example["input_ids"].shape[-1] <= max_tokens_per_batch:
+                packed_examples.append(
+                    pack_examples(examples_to_pack)
+                )
+                examples_to_pack = [example]
+                total_packed_tokens = example["input_ids"].shape[-1]
+            else:
+                packed_examples.append(
+                    pack_examples(examples_to_pack)
+                )
                 examples_to_pack = []
                 total_packed_tokens = 0
         else:


### PR DESCRIPTION
WIP
I think we were dropping a lot of data each epoch before this fix.
Dataset shuffling appears to not be working: important to try and fix this.
We should probably consider setting allow_split_batches true by default or lots of data is missed each epoch.
The approach below will only return multiple packed documents when allow_split_batches is true: don't think this is desireable.

If map_batch_size is large and pack_to_max_tokens is small I think we could end up loosing more than half the data each epoch.

still need to work out what happens to the multiple packed documents generated by this function? Do they get fed to the model 1 at a time or does only the first one? (seems like they all get seen eventually given large increase in number of steps per epoch after this fix)

Note that shuffling callback does not seem to be working:
We can inspect the packed doc id counts like so:
`min(self.doc_id_counts['afdb_s50'].keys())`

example doc id from a single packed example:
'afdb_s50/afdb_s50/A0A010R094-afdb_s50/A0A095CQN4-afdb_s50/A0A098G5G6-afdb_s50/A0A0A1TFP9-afdb_s50/A0A0C3DEM3-afdb_s50/A0A0D7F7D8-afdb_s50/A0A0E0EFP1-afdb_s50/A0A0F2P5G2-afdb_s50/A0A0G4E8G4-afdb_s50/A0A0J8QLX8-afdb_s50/A0A0M3F7J1-afdb_s50/A0A0N5AMT7-afdb_s50/A0A0P0LUJ9-afdb_s50/A0A0Q4YK00-afdb_s50/A0A0Q4ZAA6-afdb_s50/A0A0Q6S1P4-afdb_s50/A0A0Q6UGT2-afdb_s50/A0A0Q7BQW7-afdb_s50/A0A0T2KYD2-afdb_s50/A0A0V1PWC0'

we note that these doc ID keys never change between epochs (the same doc IDs are always observed together in the same batch for every epoch (although the order seems to change which is odd)