### PR TITLE
remove identifier logging

### DIFF
--- a/src/models/base.py
+++ b/src/models/base.py
@@ -1179,19 +1179,11 @@ class BaseFamilyLitModule(BaseLitModule):
 
     def on_train_start(self):
         self.dataset_sample_counts = {}
-        self.doc_id_counts = {}
 
     def on_train_epoch_end(self):
         # Commenting out as may cause deadlock in DDP
         # https://github.com/Lightning-AI/pytorch-lightning/issues/19604
         log.info("Train epoch end %s", datetime.now().strftime("%Y-%m-%d %H:%M:%S"))
-        # self.log_dict(
-        #     {
-        #         f"{k}_max_sampled_doc": max(v.values())
-        #         for k, v in self.doc_id_counts.items()
-        #     },
-        #     sync_dist=True,
-        # )
 
     def log_ds_sample_counts(self, batch):
         """Log statistics about dataset usage.


### PR DESCRIPTION
Remove doc id counts which were creating very large dictionaries and weren't being used anyway.