### PR TITLE
Single seq gym bugfix

### DIFF
--- a/src/data/tokenizers.py
+++ b/src/data/tokenizers.py
@@ -194,7 +194,7 @@ class ProFamTokenizer(PreTrainedTokenizerFast):
             max_length=max_length,
             return_token_type_ids=False,
         )
-        tokenized.data = {k: v.squeeze() for k, v in tokenized.data.items()}
+        tokenized.data = {k: v.squeeze(0) for k, v in tokenized.data.items()}
         assert tokenized.input_ids.ndim == 1
 
         if not allow_unk:
@@ -340,13 +340,9 @@ class ProFamTokenizer(PreTrainedTokenizerFast):
         residue_positions: Optional[List[int]] = None,
         bos_token="[SEP]",
         eos_token="[SEP]",
-        has_context=True,
     ):
         assert isinstance(sequences, list)
-        if has_context:
-            sequences_w_sp_tokens = [bos_token + seq + eos_token for seq in sequences]
-        else:
-            sequences_w_sp_tokens = [seq + eos_token for seq in sequences]
+        sequences_w_sp_tokens = [bos_token + seq + eos_token for seq in sequences]
         tokenized = self(
             sequences_w_sp_tokens,
             return_tensors="np",
@@ -400,4 +396,3 @@ class ProFamTokenizer(PreTrainedTokenizerFast):
         if all(len(seq) == 1 for seq in decoded_sequences):
             decoded_sequences = [seq[0] for seq in decoded_sequences]
         return decoded_sequences
-

--- a/src/models/base.py
+++ b/src/models/base.py
@@ -548,6 +548,14 @@ class BaseSingleSequenceLitModule(BaseLitModule):
             sync_dist=True,
         )
 
+        self.log(
+            "gym/log_likelihood",
+            lls.mean(),
+            on_step=False,
+            on_epoch=True,
+            prog_bar=True,
+        )
+
 
 class BaseFamilyLitModule(BaseLitModule):
     def __init__(


### PR DESCRIPTION
Fixes a mistake in the proteinGym single-sequence evaluation pipeline:
Completion sequences must start with a non-amino acid token to allow calculation of likelihood at the first amino acid position.