### PR TITLE
add length to sampler

### DIFF
--- a/src/data/datamodule.py
+++ b/src/data/datamodule.py
@@ -56,7 +56,6 @@ class ProteinDataMixture(LightningDataModule):
         feature_names: Optional[List[str]] = None,
         pack_to_max_tokens: Optional[int] = None,
         prefetch_factor: Optional[int] = None,
-        train_datasets: Optional[List[Dataset]] = [],
         # TODO: add data_return_format (needs to be same for all datasets I guess...)
     ):
         super().__init__()
@@ -90,7 +89,6 @@ class ProteinDataMixture(LightningDataModule):
         )
         self._is_setup = False
         self.total_num_train_samples = total_num_train_samples
-        self.train_datasets = train_datasets
 
     def setup(self, stage: Optional[str] = None) -> None:
         # happens on every gpu
@@ -345,6 +343,7 @@ class ProteinDataMixture(LightningDataModule):
             rank=rank,
             max_tokens=self.pack_to_max_tokens if self.pack_to_max_tokens else None,
             batch_size=self.batch_size if not self.pack_to_max_tokens else None,
+            length=self.total_num_train_samples,
         )
 
         return DataLoader(

--- a/src/data/samplers.py
+++ b/src/data/samplers.py
@@ -20,6 +20,7 @@ class MaxTokensDynamicBatchSampler(BatchSampler):
         rank: int,
         max_tokens: int = None,
         batch_size: int = None,
+        length: int = None,
     ):
         """
         Args:
@@ -40,7 +41,7 @@ class MaxTokensDynamicBatchSampler(BatchSampler):
         self.rank = rank
         self.max_tokens = max_tokens
         self.batch_size = batch_size
-
+        self.length = length
         if self.max_tokens is None and self.batch_size is None:
             raise ValueError("Either max_tokens or batch_size must be specified.")
         if self.max_tokens is not None and self.batch_size is not None:
@@ -85,4 +86,4 @@ class MaxTokensDynamicBatchSampler(BatchSampler):
         Returns:
             int: Number of batches that will be yielded for this process.
         """
-        raise TypeError(f"object of type '{type(self).__name__}' has no len()")
+        return self.length // self.world_size


### PR DESCRIPTION
Addresses problem where we were hitting this error in samplers.py:
```
    def __len__(self):
        """
        Returns:
            int: Number of batches that will be yielded for this process.
        """
        raise TypeError(f"object of type '{type(self).__name__}' has no len()")
```
in the proposed solution should the sampler length be divided by world size?