### PR TITLE
differentiate sample drawn by rank

### DIFF
--- a/src/data/samplers.py
+++ b/src/data/samplers.py
@@ -57,7 +57,7 @@ class MaxTokensDynamicBatchSampler(BatchSampler):
             # If max_tokens is specified, yield batches based on token counts
             batch = []
             current_tokens = 0
-            for idx in range(0, len(self.dataset), self.world_size):
+            for idx in range(self.rank, len(self.dataset), self.world_size):
                 tokens = self.size_fn(self.dataset[idx])  # compute tokens on-the-fly
                 # Start a new batch if adding the current sample exceeds max_tokens
                 if batch and (current_tokens + tokens > self.max_tokens):


### PR DESCRIPTION
previous implementation resulted in all devices seeing exact same batches