### PR TITLE
Fix missing num_samples arg in single-dataset training path

### DIFF
--- a/src/data/datamodule.py
+++ b/src/data/datamodule.py
@@ -135,6 +135,7 @@ class ProteinDataMixture(LightningDataModule):
                 print(f"train_dataset_names = {train_dataset_names}")
                 self.train_dataset = OnlineSampleMappingDataset(
                     dataset=train_datasets[0],
+                    num_samples=len(train_datasets[0]),
                     seed=42,
                     shuffle=self.shuffle,
                 )


### PR DESCRIPTION
OnlineSampleMappingDataset requires num_samples as a positional argument, but the single-dataset branch in ProteinDataMixture.setup() did not pass it. This causes a TypeError when training with exactly one dataset.

The multi-dataset path (WeightedConcatOnlineDataset) is unaffected, which may be why this was not caught, as I'd imagine ProFam pre-training primarily used dataset mixing.